### PR TITLE
gitmodules: point hw at the public github url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hw"]
 	path = hw
-	url = git@github.com:nvdla/hw.git
+	url = https://@github.com/nvdla/hw.git


### PR DESCRIPTION
This current pointer broke clone --recursive for users without a github account.